### PR TITLE
Proper Crypto for OAuth Token Exchange

### DIFF
--- a/oauth/random.go
+++ b/oauth/random.go
@@ -1,18 +1,39 @@
 package oauth
 
 import (
-	"math/rand"
-	"time"
+	crand "crypto/rand"
+	"encoding/binary"
+	"log"
+	rand "math/rand"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz" +
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
+var src cryptoSource
+
 func GenerateRandomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
+	rnd := rand.New(src)
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+		b[i] = charset[rnd.Intn(len(charset))]
 	}
 	return string(b)
+}
+
+type cryptoSource struct{}
+
+func (s cryptoSource) Seed(seed int64) {}
+
+func (s cryptoSource) Int63() int64 {
+	return int64(s.Uint64() & ^uint64(1<<63))
+}
+
+func (s cryptoSource) Uint64() (v uint64) {
+	err := binary.Read(crand.Reader, binary.BigEndian, &v)
+	if err != nil {
+		// The crand.Reader returns an error if the underlying system call fails. For instance if it can't read /dev/urandom on a Unix system, or if CryptAcquireContext fails on a Windows system.
+		log.Fatal(err)
+	}
+	return v
 }


### PR DESCRIPTION
Fixes one thing found in #6  

This Pull Request creates an simple interface around `math/rand` and `crypto/rand` for the usage in `GenerateRandomString`

This approach should be sufficiently secure for our purposes.